### PR TITLE
Update `voici` and `jupyterlite-xeus` dependencies

### DIFF
--- a/script/build-environment.yml
+++ b/script/build-environment.yml
@@ -5,6 +5,5 @@ dependencies:
   - python
   - pip
   - nodejs=18
-  - pip:
-      - voici>=0.5.0rc0,<0.6.0
-      - jupyterlite-xeus-python>=1.0.0a3,<2.0.0
+  - voici >=0.7.0,<0.8.0
+  - jupyterlite-xeus >=2.0.0,<3.0.0


### PR DESCRIPTION
Update to the latest versions of `voici` and `jupyterlite-xeus`:

- https://github.com/voila-dashboards/voici/releases/tag/v0.7.0
- https://github.com/jupyterlite/xeus/releases/tag/v2.0.0