### PR TITLE
Switch to `mamba-org/setup-micromamba@v1`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,9 +21,9 @@ jobs:
           python-version: '3.10'
 
       - name: Install mamba
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v1
         with:
-          micromamba-version: '1.4.2'
+          micromamba-version: '1.5.8-0'
           environment-file: 'script/build-environment.yml'
 
       - name: Build the gallery site


### PR DESCRIPTION
To fix the following warning:

![image](https://github.com/user-attachments/assets/409701c5-22e6-4574-88d1-03885cdb84f8)
